### PR TITLE
remove dkms as package requirement 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # Intel® Platform Monitoring Technology Backports
 
 This repo holds backports of the pmt driver.
@@ -113,7 +112,3 @@ To install, run:
 cp $HOME/rpmbuild/RPMS/x86_64/*.rpm .
 sudo dnf install intel-platform-pmt-dkms*.rpm
 ```
-=======
-# drivers.platform.kernel.pmt.backporting
-Used for backporting Platform Monitoring Technology driver to sles15sp2
->>>>>>> 9055c7a (initial add)

--- a/scripts/backport-mkdkmsspec
+++ b/scripts/backport-mkdkmsspec
@@ -36,7 +36,7 @@ sed -e '/^DEL/d' -e 's/^\t*//' <<EOF
 	Vendor: Intel
 	Provides: %{module}
 	Packager: linux-graphics@intel.com
-	Requires: dkms gcc bash sed
+	Requires: gcc bash sed
 	# There is no Source# line for dkms.conf since it has been placed
 	# into the source tarball of SOURCE0
 	Source0: %{module}-%{version}-src.tar.gz


### PR DESCRIPTION
dkms package is not available on rhel without adding epel.  dkms could come from source without adding epel in which case we should permit installing without dkms package requirement.